### PR TITLE
Switch c9 workspace confix.exs host to reflect newly created instance

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -23,7 +23,7 @@ config :logger, :console,
   metadata: [:request_id]
   
 # Configure hound  
-config :hound, driver: "phantomjs", host: "https://phoenix-inside-out-tansaku.c9users.io", port: 8082
+config :hound, driver: "phantomjs", host: "https://mastering-phoenix-framework-federicoesparza.c9users.io", port: 8082
  
 
 # Import environment specific config. This must remain at the bottom


### PR DESCRIPTION
Not sure if we really want to keep version control of the new Mob repo, but it might be useful again down the line.